### PR TITLE
Update Google signup form link

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ take a more advanced course or choose another course of interest.__
 ### 1.1 Sign up
 
 To be considered for the SI 506 waiver, you must first complete the Google sign up
-[form](https://docs.google.com/forms/d/1nBJUyvv1wZnNG8NllQTwp0L8bDEtgfh9ihQZp064Gnc/prefill) in order
+[form](https://docs.google.com/forms/d/e/1FAIpQLSf6j0jYmvPHoBc0fe86F05KS_Uk0cvR) in order
 to be granted access to the assignment. If you do not complete this form, you will not be considered
 for the waiver.
 


### PR DESCRIPTION
This PR updates the link to the Google signup form. The earlier link forced students to request access to the form.